### PR TITLE
Fixing redundant writing

### DIFF
--- a/matching_test.go
+++ b/matching_test.go
@@ -8,16 +8,16 @@ import (
 
 func TestGaleShapley4x4(t *testing.T) {
 	msPrefers := [][]int{
-		[]int{0, 1, 2, 3},
-		[]int{3, 0, 1, 2},
-		[]int{1, 3, 2, 0},
-		[]int{0, 2, 3, 1},
+		{0, 1, 2, 3},
+		{3, 0, 1, 2},
+		{1, 3, 2, 0},
+		{0, 2, 3, 1},
 	}
 	wsPrefers := [][]int{
-		[]int{0, 1, 2, 3},
-		[]int{1, 2, 3, 0},
-		[]int{0, 3, 2, 1},
-		[]int{3, 2, 0, 1},
+		{0, 1, 2, 3},
+		{1, 2, 3, 0},
+		{0, 3, 2, 1},
+		{3, 2, 0, 1},
 	}
 	answer := map[int]int{0: 0, 1: 2, 2: 3, 3: 1}
 	result := matching.GaleShapley(msPrefers, wsPrefers)
@@ -30,16 +30,16 @@ func TestGaleShapley4x4(t *testing.T) {
 
 func TestGaleShapley3x3(t *testing.T) {
 	msPrefers := [][]int{
-		[]int{2, 3, 1},
-		[]int{2, 1, 3},
-		[]int{0, 3, 2},
-		[]int{0, 2, 3},
+		{2, 3, 1},
+		{2, 1, 3},
+		{0, 3, 2},
+		{0, 2, 3},
 	}
 	wsPrefers := [][]int{
-		[]int{1, 3, 0},
-		[]int{3, 1, 0},
-		[]int{1, 2, 3},
-		[]int{0, 1, 2},
+		{1, 3, 0},
+		{3, 1, 0},
+		{1, 2, 3},
+		{0, 1, 2},
 	}
 	answer := map[int]int{0: 3, 2: 1, 3: 0}
 	result := matching.GaleShapley(msPrefers, wsPrefers)
@@ -52,16 +52,16 @@ func TestGaleShapley3x3(t *testing.T) {
 
 func TestGaleShapley2x2(t *testing.T) {
 	msPrefers := [][]int{
-		[]int{2, 3},
-		[]int{2, 1},
-		[]int{0, 3},
-		[]int{0, 2},
+		{2, 3},
+		{2, 1},
+		{0, 3},
+		{0, 2},
 	}
 	wsPrefers := [][]int{
-		[]int{1, 0},
-		[]int{3, 0},
-		[]int{1, 3},
-		[]int{0, 2},
+		{1, 0},
+		{3, 0},
+		{1, 3},
+		{0, 2},
 	}
 	answer := map[int]int{2: 1, 3: 0}
 	result := matching.GaleShapley(msPrefers, wsPrefers)
@@ -74,16 +74,16 @@ func TestGaleShapley2x2(t *testing.T) {
 
 func TestGaleShapley1x1(t *testing.T) {
 	msPrefers := [][]int{
-		[]int{0},
-		[]int{1},
-		[]int{3},
-		[]int{0},
+		{0},
+		{1},
+		{3},
+		{0},
 	}
 	wsPrefers := [][]int{
-		[]int{0},
-		[]int{1},
-		[]int{3},
-		[]int{2},
+		{0},
+		{1},
+		{3},
+		{2},
 	}
 	answer := map[int]int{0: 0, 1: 1, 3: 2}
 	result := matching.GaleShapley(msPrefers, wsPrefers)


### PR DESCRIPTION
Closes #1 

Fixing redundant writing in slice and map in matching_test.go

Reference
[https://go.dev/ref/spec#Composite_literals](https://go.dev/ref/spec#Composite_literals)